### PR TITLE
#1063469 Add compatibility with Redmine 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,8 @@
-# Localizable
+# Localizable Changes
 
-In Redmine when you add roles, issue statuses, enumerations, ... you can only add them in one language, this plugin overloads this limitation.
+1.0.0
+----------
 
-This plugin allows to define customizable locales in any language for these items:
-
-- Roles.
-- Trackers (issues types).
-- Issue statuses.
-- Custom fields.
-- Enumerations.
-
-Once installed, go to Administration, Extensions and click on Configuration link on this plugin.
-
-## Installation notes
-
-Steps:
-
-1. Download last version from: https://github.com/southbridgeio/localizable.git
-2. Copy plugin directory into #{RAILS_ROOT}/plugins.
-3. Run the following command in #{RAILS_ROOT} to upgrade your database: `bundle exec rake redmine:plugins:migrate NAME=localizable RAILS_ENV=production`
-4. Restart Redmine.
-
-Original: http://www.redmine.org/plugins/localizable
-
-## Support notes
 This is a Localizable plugin of version "0.4.0" updated with SouthBridge.
 
 Compatibility: Redmine 6.1 / Rails 7.2 / Ruby 3.3
@@ -44,3 +23,8 @@ Modern Ruby/Rails patterns:
 
 Testing:
 - Plugin tested with Redmine 6.1.0-stable, Rails 7.2.2.2, Ruby 3.3.10
+
+0.4.0
+----------
+Basic version of "Localizable plugin"
+- https://redmine.ociotec.com/projects/localizable

--- a/app/views/settings/_localizable.html.erb
+++ b/app/views/settings/_localizable.html.erb
@@ -88,7 +88,7 @@
     <%- @settings["locales"][element[:name]][object.id.to_s] = {} if @settings["locales"][element[:name]][object.id.to_s].nil? -%>
     <tr>
       <td>
-        <%= object.name(true) %>
+        <%= object.name(original: true) %>
       </td>
       <%- @settings["locales_to_translate"].each do |locale| -%>
       <td align="left">

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -7,36 +5,36 @@
 #   * No derivates of this plugin (or partial) are allowed.
 # Take a look to licence.txt file at plugin root folder for further details.
 
-# This plugin should be reloaded in development mode.
-if (Rails.env == "development")
-  mapped_paths = ActiveSupport::Dependencies.autoload_once_paths.map { |path| path =~ /^#{Regexp.escape(File.dirname(__FILE__))}/ }
-  ActiveSupport::Dependencies.autoload_once_paths = mapped_paths
-end
-
 require "redmine"
-require "rubygems"
-require_dependency "./plugins/localizable/lib/localizable/view_hooks"
+
+require File.expand_path('lib/localizable', __dir__)
+require File.expand_path('lib/localizable/view_hooks', __dir__)
 
 Rails.configuration.to_prepare do
-  require_dependency 'project'
-  require_dependency 'principal'
-  require_dependency 'user'
-  User.send(:include, Localizable::UserPatch)
+  require_relative 'lib/localizable/user_patch'
+  require_relative 'lib/localizable/role_patch'
+  require_relative 'lib/localizable/tracker_patch'
+  require_relative 'lib/localizable/issue_status_patch'
+  require_relative 'lib/localizable/custom_field_patch'
+  require_relative 'lib/localizable/enumeration_patch'
 end
 
-Role.send(:include, RolePatch)
-Tracker.send(:include, TrackerPatch)
-IssueStatus.send(:include, IssueStatusPatch)
-CustomField.send(:include, CustomFieldPatch)
-Enumeration.send(:include, EnumerationPatch)
+Rails.application.config.after_initialize do
+  User.prepend(Localizable::UserPatch) unless User.ancestors.include?(Localizable::UserPatch)
+  Role.prepend(Localizable::RolePatch) unless Role.ancestors.include?(Localizable::RolePatch)
+  Tracker.prepend(Localizable::TrackerPatch) unless Tracker.ancestors.include?(Localizable::TrackerPatch)
+  IssueStatus.prepend(Localizable::IssueStatusPatch) unless IssueStatus.ancestors.include?(Localizable::IssueStatusPatch)
+  CustomField.prepend(Localizable::CustomFieldPatch) unless CustomField.ancestors.include?(Localizable::CustomFieldPatch)
+  Enumeration.prepend(Localizable::EnumerationPatch) unless Enumeration.ancestors.include?(Localizable::EnumerationPatch)
+end
 
 Redmine::Plugin.register :localizable do
   name "Localizable plugin"
   url "https://redmine.ociotec.com/projects/localizable"
-  author "Emilio González Montaña"
+  author "Emilio González Montaña | SouthBridge"
   author_url "http://ociotec.com"
   description "This is a plugin for Redmine that is used to show strings (issue types, issue statuses, enumerations, ...) in serveral languages"
-  version "0.4.0"
+  version "1.0.0"
   requires_redmine :version_or_higher => "2.1.0"
 
   settings(:default => {"default_language" => "en",

--- a/lib/localizable.rb
+++ b/lib/localizable.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.

--- a/lib/localizable/custom_field_patch.rb
+++ b/lib/localizable/custom_field_patch.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -7,16 +5,10 @@
 #   * No derivates of this plugin (or partial) are allowed.
 # Take a look to licence.txt file at plugin root folder for further details.
 
-require_dependency "custom_field"
-
-module CustomFieldPatch
-  def self.included(base)
-    base.class_eval do
-
-      def name(original = false)
-        return(original ? super() : Localizable.localize("custom_field", id, super()))
-      end
-
+module Localizable
+  module CustomFieldPatch
+    def name(original: false)
+      original ? super() : Localizable.localize("custom_field", id, super())
     end
   end
 end

--- a/lib/localizable/enumeration_patch.rb
+++ b/lib/localizable/enumeration_patch.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -7,16 +5,10 @@
 #   * No derivates of this plugin (or partial) are allowed.
 # Take a look to licence.txt file at plugin root folder for further details.
 
-require_dependency "role"
-
-module RolePatch
-  def self.included(base)
-    base.class_eval do
-
-      def name(original = false)
-        return(original ? super() : Localizable.localize("role", id, super()))
-      end
-
+module Localizable
+  module EnumerationPatch
+    def name(original: false)
+      original ? super() : Localizable.localize("enumeration", id, super())
     end
   end
 end

--- a/lib/localizable/issue_status_patch.rb
+++ b/lib/localizable/issue_status_patch.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -7,16 +5,10 @@
 #   * No derivates of this plugin (or partial) are allowed.
 # Take a look to licence.txt file at plugin root folder for further details.
 
-require_dependency "tracker"
-
-module TrackerPatch
-  def self.included(base)
-    base.class_eval do
-
-      def name(original = false)
-        return(original ? super() : Localizable.localize("tracker", id, super()))
-      end
-
+module Localizable
+  module IssueStatusPatch
+    def name(original: false)
+      original ? super() : Localizable.localize("issue_status", id, super())
     end
   end
 end

--- a/lib/localizable/role_patch.rb
+++ b/lib/localizable/role_patch.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -7,16 +5,10 @@
 #   * No derivates of this plugin (or partial) are allowed.
 # Take a look to licence.txt file at plugin root folder for further details.
 
-require_dependency "enumeration"
-
-module EnumerationPatch
-  def self.included(base)
-    base.class_eval do
-
-      def name(original = false)
-        return(original ? super() : Localizable.localize("enumeration", id, super()))
-      end
-
+module Localizable
+  module RolePatch
+    def name(original: false)
+      original ? super() : Localizable.localize("role", id, super())
     end
   end
 end

--- a/lib/localizable/tracker_patch.rb
+++ b/lib/localizable/tracker_patch.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -7,16 +5,10 @@
 #   * No derivates of this plugin (or partial) are allowed.
 # Take a look to licence.txt file at plugin root folder for further details.
 
-require_dependency "issue_status"
-
-module IssueStatusPatch
-  def self.included(base)
-    base.class_eval do
-
-      def name(original = false)
-        return(original ? super() : Localizable.localize("issue_status", id, super()))
-      end
-
+module Localizable
+  module TrackerPatch
+    def name(original: false)
+      original ? super() : Localizable.localize("tracker", id, super())
     end
   end
 end

--- a/lib/localizable/user_patch.rb
+++ b/lib/localizable/user_patch.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Copyright © Emilio González Montaña
 # Licence: Attribution & no derivates
 #   * Attribution to the plugin web page URL should be done if you want to use it.
@@ -9,25 +7,17 @@
 
 module Localizable
   module UserPatch
-    def self.included(base)
-      base.send(:include, InstanceMethods)
-
+    def self.prepended(base)
       base.class_eval do
-        # Same as typing in the class.
-        unloadable # Send unloadable so it will not be unloaded in development.
         safe_attributes 'name_in_english'
-
-        alias_method :name_without_localizable, :name
-        alias_method :name, :name_with_localizable
       end
     end
-  end
-  module InstanceMethods
-    def name_with_localizable(formatter = nil)
-      if  User.current.language.to_s == 'en' and name_in_english.present?
+
+    def name(formatter = nil)
+      if User.current.language.to_s == 'en' && name_in_english.present?
         name_in_english
       else
-        name_without_localizable(formatter)
+        super
       end
     end
   end

--- a/lib/localizable/view_hooks.rb
+++ b/lib/localizable/view_hooks.rb
@@ -1,15 +1,13 @@
 module Localizable
   class ViewHooks < Redmine::Hook::ViewListener
     def view_my_account(context={})
-      <<-SRC
-        <p>#{context[:form].text_field :name_in_english, :value => context[:user].name_in_english}</p>
-      SRC
+      return '' unless context[:form] && context[:user]
+      "<p>#{context[:form].text_field :name_in_english, autocomplete: 'none'}</p>".html_safe
     end
 
     def view_users_form(context={})
-      <<-SRC
-        <p>#{context[:form].text_field :name_in_english, :value => context[:user].name_in_english}</p>
-      SRC
+      return '' unless context[:form] && context[:user]
+      "<p>#{context[:form].text_field :name_in_english, autocomplete: 'none'}</p>".html_safe
     end
   end
 end


### PR DESCRIPTION
## Update notes
This is a Localizable plugin of version "0.4.0" updated with SouthBridge.

Compatibility: Redmine 6.1 / Rails 7.2 / Ruby 3.3

Redmine 6.1 compatibility:
- fix view hooks logic for `name_in_english` field

Rails 7 autoloading compatibility:
- Removed deprecated `require_dependency` calls
- Replaced with `require_relative` inside `Rails.configuration.to_prepare` block
- Removed `ActiveSupport::Dependencies` manipulation code

Modern Ruby/Rails patterns:
- Refactored from include + alias_method pattern to prepend
- Changed patch application to `after_initialize` for proper loading
- Updated all model patches (Role, Tracker, IssueStatus, CustomField, Enumeration, User)
- Removed unnecessary # encoding: UTF-8 comments (UTF-8 is default in Ruby 3.3)

Testing:
- Plugin tested with Redmine 6.1, Rails 7.2, Ruby 3.3.10